### PR TITLE
[Issue#31] Aplicar responsividade a página de Código de Conduta

### DIFF
--- a/src/assets/sass/_exportable.scss
+++ b/src/assets/sass/_exportable.scss
@@ -13,3 +13,11 @@ $light-white: #dde5e9;
 
 $dark-blue: #269fa2;
 $light-blue: #4eb8b4;
+
+
+// Breakpoints based on bulma responsiveness
+$mobile: 768px;
+$tablet: 1023px;
+$desktop: 1024px;
+$widescreen: 1216px;
+$fullHD: 1408px;

--- a/src/assets/sass/_global.scss
+++ b/src/assets/sass/_global.scss
@@ -1,3 +1,12 @@
+:root {
+  // font-size variables
+  --h2-size-desktop: calc(48 / 16 * 1rem);
+  --h2-size-mobile: calc(40 / 16 * 1rem);
+  --h4-size-desktop: calc(28 / 16 * 1rem);
+  --h4-size-mobile: calc(16 / 16 * 1rem);
+  --p-size-mobile: calc(16 / 16 * 1rem);
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/src/components/pages/DutyPage/index.js
+++ b/src/components/pages/DutyPage/index.js
@@ -12,7 +12,15 @@ const DutyPage = ({ text }) => {
   return (
     <div id="duty">
       <main>
-        <img className="background" src={BackgroundImage} alt="Imagem de fundo" />
+        <div className="duty__adornment">
+          <img
+            className="background"
+            src={BackgroundImage}
+            // Descrever adereços é uma má prática para acessibilidade. 
+            // https://www.ufrgs.br/acessibilidadedigital/atributo-alt/ 
+            alt=""
+          />
+        </div>
         <div className="container">
           <div className="row">
             <div className="heading col-12 col-sm-9">

--- a/src/components/pages/DutyPage/index.js
+++ b/src/components/pages/DutyPage/index.js
@@ -25,8 +25,6 @@ const DutyPage = ({ text }) => {
                 O evento Python Brasil é um ambiente amistoso, de boa
                 convivência, inclusivo e livre de intimidação, onde todas as
                 pessoas são bem-vindas e a civilidade é exigida.
-                <br />
-                <br />
               </p>
               <p>
                 Com esta finalidade, a organização do evento conta com uma
@@ -34,12 +32,8 @@ const DutyPage = ({ text }) => {
                 qualidades.
               </p>
 
-              <br />
-              <br />
-              <br />
-
               <p> Por isso: </p>
-              <br />
+
               <ul>
                 <li>
                   Não é tolerado nenhum tipo de assédio, discriminação
@@ -52,11 +46,8 @@ const DutyPage = ({ text }) => {
                 </li>
               </ul>
 
-              <br />
-              <br />
-
               <p>Desta forma, entendemos que:</p>
-              <br />
+
               <ul>
                 <li>
                   Assédio é a ação de insistir, perseguir ou coagir outra pessoa
@@ -73,8 +64,6 @@ const DutyPage = ({ text }) => {
                 </li>
               </ul>
 
-              <br />
-              <br />
               <p>
                 O público alvo do evento também inclui crianças e adolescentes,
                 por isso buscamos manter um ambiente apropriado para todas as
@@ -83,16 +72,13 @@ const DutyPage = ({ text }) => {
                 patrocinadores.
               </p>
 
-              <br />
-              <br />
               <p>
                 {" "}
                 Se você se sentiu assediado, discriminado indevidamente ou
                 humilhado, ou presenciou alguma destas atitudes, por favor entre
                 em contato com a Equipe de Resposta.{" "}
               </p>
-              <br />
-              <br />
+
               <p>
                 {" "}
                 Havendo um relato de violação destes princípios, a Equipe de
@@ -103,8 +89,6 @@ const DutyPage = ({ text }) => {
                 indeterminado.{" "}
               </p>
 
-              <br />
-              <br />
               <span className="last-update">
                 Última atualização: 29 de Março de 2022
               </span>

--- a/src/components/pages/DutyPage/style.scss
+++ b/src/components/pages/DutyPage/style.scss
@@ -38,17 +38,24 @@
   @media (max-width: ($tablet)) {
     main {
       padding: 0 28px 190px;
-
-      img.background {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-      }
+      // Overflow hidden para poder escalar a imagem de adereço
+      overflow: hidden;
     }
 
     .heading {
       margin-top: 55px;
       margin-bottom: 25px;
+    }
+
+    .duty__adornment {
+      width: fit-content;
+      margin: 0 -28px;
+
+      img.background {
+        width: 165%;
+        object-fit: contain;
+        object-position: left bottom;
+      }
     }
 
     p,

--- a/src/components/pages/DutyPage/style.scss
+++ b/src/components/pages/DutyPage/style.scss
@@ -1,5 +1,4 @@
 #duty {
-
   main {
     position: relative;
     padding-bottom: 190px;
@@ -20,8 +19,9 @@
   p {
     font-size: 20px;
     line-height: 28px;
-    color: #3A3A3C;
-    font-family: 'Manrope', sans-serif;
+    color: #3a3a3c;
+    font-family: "Manrope", sans-serif;
+    margin: 20px 0;
   }
   ul li {
     list-style: disc;
@@ -32,6 +32,28 @@
     color: #6b7588;
     font-size: 14px;
     line-height: 20px;
-    font-family: 'Manrope', sans-serif;
+    font-family: "Manrope", sans-serif;
+  }
+
+  @media (max-width: ($tablet)) {
+    main {
+      padding: 0 28px 190px;
+
+      img.background {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+      }
+    }
+
+    .heading {
+      margin-top: 55px;
+      margin-bottom: 25px;
+    }
+
+    p,
+    ul li {
+      font-size: var(--p-size-mobile);
+    }
   }
 }

--- a/src/components/shared/IconTitle/index.js
+++ b/src/components/shared/IconTitle/index.js
@@ -1,13 +1,14 @@
-import React from 'react'
+import React from "react";
 
-import './style.scss';
+import "./style.scss";
 
 const IconTitle = ({ title, icon }) => (
   <div className="icon-title">
-    <img src={icon} alt={title} />
+    <h4 className="icon-title__mobile">#PYTHONBRASIL2022</h4>
     <h2>{title}</h2>
-    <h4>#PYTHONBRASIL2022</h4>
+    <h4 className="icon-title__desktop">#PYTHONBRASIL2022</h4>
+    <img src={icon} alt={title} />
   </div>
-)
+);
 
-export default IconTitle
+export default IconTitle;

--- a/src/components/shared/IconTitle/style.scss
+++ b/src/components/shared/IconTitle/style.scss
@@ -6,7 +6,7 @@
   h2 {
     font-family: "Montserrat", sans-serif;
     font-weight: 900;
-    font-size: 48px;
+    font-size: var(--h2-size-desktop);
     text-transform: uppercase;
   }
 
@@ -15,12 +15,48 @@
     text-transform: uppercase;
     color: $light-green;
     font-weight: 400;
-    font-size: 28px;
+    font-size: var(--h4-size-desktop);
   }
 
   img {
     position: absolute;
     right: 40px;
     top: 0;
+  }
+
+  .icon-title__mobile {
+    display: none;
+  }
+
+  @media (max-width: ($tablet)) {
+    display: flex;
+    gap: 8px;
+    min-width: 100%;
+    padding-top: 24px;
+    margin: 0 0 5px 0;
+
+    .icon-title__mobile {
+      display: revert;
+    }
+    .icon-title__desktop {
+      display: none;
+    }
+
+    h2 {
+      font-size: var(--h2-size-mobile);
+    }
+    h4 {
+      font-size: var(--h4-size-mobile);
+      line-height: var(--h4-size-mobile);
+      margin: 0;
+      position: absolute;
+      top: 0;
+    }
+    img {
+      line-height: 0;
+      right: 0;
+      position: relative;
+      align-self: flex-start;
+    }
   }
 }


### PR DESCRIPTION
## Links:
- [Issue#31](https://github.com/pythonbrasil/pybr2022-site/issues/31)
- [Figma#Código de Conduta Mobile](https://www.figma.com/file/mNxbwSMw0ugpJhetfYCi3M/Phyton-Brasil-2022?node-id=477%3A777)

## Descrição
- Nesse PR adicionei responsividade à página de Código de Conduta;
- Também foram adicionadas variáveis globais CSS para organizar o uso de font-size e breakpoints da aplicação;
- A responsividade do navbar e footer não foi corrigida, esse PR foca apenas na section da página de Código de Conduta.

## Como testar:
- Rode a aplicação com `yarn start` ou `yarn develop`;
- Vá para a página de Código de Conduta em `localhost:8000/cdc`;
- Redimensione sua tela para verificar se há alguma quebra no layout. 

## Screenshots:

https://user-images.githubusercontent.com/42525687/169832831-11371b74-232c-4753-b89f-5d9ccaefe680.mp4






