### PR TITLE
[Issue#30] Adicionar responsividade a página de sobre

### DIFF
--- a/src/assets/sass/_global.scss
+++ b/src/assets/sass/_global.scss
@@ -58,3 +58,20 @@ button {
 .container-xxl {
   max-width: 1134px;
 }
+
+.desktop-only {
+  display: revert;
+}
+
+.tablet-only {
+  display: none;
+}
+
+@media (max-width: ($tablet)) {
+  .desktop-only {
+    display: none;
+  }
+  .tablet-only {
+    display: revert;
+  }
+}

--- a/src/components/pages/HomePage/index.js
+++ b/src/components/pages/HomePage/index.js
@@ -2,11 +2,11 @@ import React, { useState } from "react";
 
 import TitleChip from "@components/shared/TitleChip";
 import Footer from "@components/shared/Footer";
-import IconTitle from '@components/shared/IconTitle';
-import LandingBackground from "@images/home/bg_landing_page.svg"
-import SponsoringBackground from "@images/home/bg_cta.svg"
-import GirlImage from "@images/home/girl.svg"
-import CalendarIcon from "@images/home/calendar.svg"
+import IconTitle from "@components/shared/IconTitle";
+import LandingBackground from "@images/home/bg_landing_page.svg";
+import SponsoringBackground from "@images/home/bg_cta.svg";
+import GirlImage from "@images/home/girl.svg";
+import CalendarIcon from "@images/home/calendar.svg";
 
 import VirusIcon from "@images/home/covid/virus.svg";
 import GearIcon from "@images/home/covid/gear.svg";
@@ -83,13 +83,24 @@ const HomePage = ({ text, file }) => {
       </section>
       <section id="section-info">
         <div className="container">
-          <div className="row">
-            <div className="col-6 image-column">
+          <div className="row section-info__content">
+            <div className="tablet-only section-info__title">
+              <TitleChip>Sobre a Python BR</TitleChip>
+            </div>
+            <div className="col-6 image-column desktop-only">
               <img src={GirlImage} alt="" />
             </div>
-            <div className="col-6">
-              <TitleChip>Sobre a Python BR</TitleChip>
+            <div className="col-6 section-info__about">
+              <div className="desktop-only">
+                <TitleChip>Sobre a Python BR</TitleChip>
+              </div>
               <div className="info">
+                <img
+                  src={GirlImage}
+                  alt=""
+                  className="section-info__image tablet-only"
+                />
+
                 <p>
                   A Python Brasil 2022 é a maior conferência sobre linguagem de
                   programação Python do Brasil e da América Latina.

--- a/src/components/pages/HomePage/style.scss
+++ b/src/components/pages/HomePage/style.scss
@@ -5,7 +5,7 @@ section {
   padding: 80px 0;
 }
 
-.link-sponsor{
+.link-sponsor {
   color: #fff;
 }
 
@@ -48,13 +48,51 @@ section {
     font-size: 18px;
     color: $white;
   }
+
+  @media (max-width: ($tablet)) {
+    padding: 80px 20px;
+
+    .info {
+      margin-top: 80px;
+      font-size: var(--p-size-mobile);
+    }
+
+    .section-info__image {
+      max-width: 200px;
+      line-height: 0;
+      float: right;
+      object-fit: cover;
+      object-position: 15px;
+    }
+    .section-info__about {
+      width: 100%;
+    }
+    .section-info__content {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .section-info__title {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  }
+
+  @media (max-width: ($mobile)) {
+    .section-info__image {
+      width: 150px;
+    }
+  }
 }
+
 #section-sponsoring {
   text-align: center;
   position: relative;
   background: $orange;
   padding: 64px 0;
-  overflow-x: hidden;
+  overflow: hidden;
 
   h3 {
     background: #e67b2a;
@@ -96,7 +134,6 @@ section {
     margin-top: 20px;
 
     li {
-
       .card {
         background: $dark-blue;
         width: 100%;
@@ -105,15 +142,16 @@ section {
         text-align: left;
         padding: 20px;
 
-        h2, p {
+        h2,
+        p {
           color: #fff;
         }
 
         img {
           width: 36px;
           height: 36px;
-          border: 6px solid #FFF;
-          background: #FFF;
+          border: 6px solid #fff;
+          background: #fff;
           border-radius: 20px;
           margin-bottom: 10px;
         }
@@ -173,8 +211,8 @@ section {
 
       li {
         &.active button {
-          background: #FAFBFF;
-          color: #3A3A3C;
+          background: #fafbff;
+          color: #3a3a3c;
 
           &::before {
             background: $dark-green;
@@ -186,24 +224,23 @@ section {
           outline: none;
           font-size: 18px;
           padding: 20px calc(8% + 20px);
-          background: #FFF;
-          color: #6B7588;
+          background: #fff;
+          color: #6b7588;
           font-weight: 400;
           position: relative;
           transition: color 250ms ease-in-out, background 250ms ease-in-out;
           width: 100%;
           text-align: left;
 
-
           &:hover,
           &:active {
-            background: #FAFBFF;
+            background: #fafbff;
           }
 
           &::before {
             content: "";
             display: inline-block;
-            background: #93D0AC;
+            background: #93d0ac;
             width: 20px;
             height: 20px;
             position: absolute;
@@ -215,7 +252,7 @@ section {
           }
           &:after {
             content: "";
-            background: url('../../../assets/images/home/faq/arrow.svg');
+            background: url("../../../assets/images/home/faq/arrow.svg");
             position: absolute;
             top: 50%;
             transform: translateY(-50%);
@@ -237,7 +274,8 @@ section {
     border-radius: 12px;
     left: 50%;
     transform: translateX(-50%);
-    transition: left 500ms ease, transform 500ms ease, max-width 500ms ease, height 500ms ease;
+    transition: left 500ms ease, transform 500ms ease, max-width 500ms ease,
+      height 500ms ease;
 
     .right-panel-inner {
       width: 68.5%;
@@ -256,16 +294,16 @@ section {
     h3 {
       font-size: 22px;
       line-height: 26px;
-      font-family: 'Montserrat', sans-serif;
+      font-family: "Montserrat", sans-serif;
       margin-bottom: 32px;
     }
 
-    h3, p {
-      color: #FFF;
+    h3,
+    p {
+      color: #fff;
     }
   }
 }
-
 
 footer {
   padding: 70px 0 50px;
@@ -297,19 +335,19 @@ footer {
     margin: 10px auto;
 
     a {
-      color: #047F4D;
+      color: #047f4d;
       text-decoration: none;
-      font-family: 'Manrope', sans-serif;
+      font-family: "Manrope", sans-serif;
     }
   }
 
   h4 {
-    font-family: 'Manrope', sans-serif;
+    font-family: "Manrope", sans-serif;
     text-transform: uppercase;
     font-size: 14px;
     font-weight: 400;
     letter-spacing: 3px;
-    color: #3A3A3C;
+    color: #3a3a3c;
     margin-bottom: 30px;
   }
 
@@ -320,13 +358,13 @@ footer {
 }
 
 .privacy-policy {
-  background: #F4EDDB;
+  background: #f4eddb;
   padding: 50px 0 60px;
-  color: #3A3A3C;
-  font-family: 'Roboto', sans-serif;
+  color: #3a3a3c;
+  font-family: "Roboto", sans-serif;
 }
 @keyframes fadeOut {
-  0%{
+  0% {
     opacity: 0;
   }
   100% {

--- a/src/components/pages/HomePage/style.scss
+++ b/src/components/pages/HomePage/style.scss
@@ -50,10 +50,11 @@ section {
   }
 
   @media (max-width: ($tablet)) {
+   
     padding: 80px 20px;
 
     .info {
-      margin-top: 80px;
+      margin-top: 40px;
       font-size: var(--p-size-mobile);
     }
 
@@ -77,6 +78,10 @@ section {
       display: flex;
       justify-content: center;
       align-items: center;
+    }
+
+    h3{
+      text-align: center;
     }
   }
 

--- a/src/components/shared/TitleChip/style.scss
+++ b/src/components/shared/TitleChip/style.scss
@@ -3,10 +3,14 @@ h3.chip-title {
   margin: 0 auto 24px;
   color: #fff;
   font-family: "Montserrat", sans-serif;
-  font-size: 32px;
+  font-size: calc(32 / 16 * 1rem);
   font-weight: 700;
   display: inline-block;
   padding: 10px 20px;
   border-radius: 10px;
   width: auto;
+
+  @media (max-width: ($tablet)) {
+    font-size: calc(24 / 16 * 1rem);
+  }
 }

--- a/src/configs/languages/text-ptbr.js
+++ b/src/configs/languages/text-ptbr.js
@@ -3,18 +3,19 @@ export const TEXT_PTBR = {
     LANDING: {
       TITLE: `17 a 23 de Outubro 2022`,
       INFO: `A submissão de palestras para o Python Brasil 2022 pode ser feita pelo botão abaixo.`,
-      BUTTON: `Submeta sua palestra aqui`
+      BUTTON: `Submeta sua palestra aqui`,
     },
     SPONSORING: {
-      BUTTON: `Veja nosso plano de patrocínio`
+      TITLE: "Saiba como patrocinar o evento",
+      BUTTON: `Veja nosso plano de patrocínio`,
     },
     FOOTER: {
-      ABOUT_TEXT: `PythonBrasil é uma conferência sem fins lucrativos dirigida por voluntários para promover a linguagem de programação Python de código aberto. É apoiado pela Associação Python Brasil (APyB) e pela Python Software Foundation (PSF).`
-    }
+      ABOUT_TEXT: `PythonBrasil é uma conferência sem fins lucrativos dirigida por voluntários para promover a linguagem de programação Python de código aberto. É apoiado pela Associação Python Brasil (APyB) e pela Python Software Foundation (PSF).`,
+    },
   },
   CDC: {
     LANDING: {
-      TITLE: `Código de Conduta`
-    }
-  }
-}
+      TITLE: `Código de Conduta`,
+    },
+  },
+};


### PR DESCRIPTION
## Links:
- [Issue#30](https://github.com/pythonbrasil/pybr2022-site/issues/30)
- [Figma#HomePage](https://www.figma.com/file/mNxbwSMw0ugpJhetfYCi3M/Phyton-Brasil-2022?node-id=477%3A420)

## Descrição
- Nesse PR adicionei responsividade à seção de sobre;
- Também foram adicionadas classes para ocultar e mostrar elementos de acordo com o @media queries.


## Como testar:
- Rode a aplicação com `yarn start` ou `yarn develop`;
- Vá para a página de Home em `localhost:8000/`;
- Redimensione sua tela para verificar se há alguma quebra no layout na sessão de sobre (a seção que fala um pouco sobre a pybr)

## Screenshots:

https://user-images.githubusercontent.com/42525687/170109653-d5e4585e-2752-444c-b197-e10ff251c9f5.mp4







