### PR TITLE
[Issue#66] Fix titulo das paginas

### DIFF
--- a/src/components/pages/DutyPage/index.js
+++ b/src/components/pages/DutyPage/index.js
@@ -1,10 +1,10 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 
 import BookIcon from "@images/duty/book.svg";
 import BackgroundImage from "@images/duty/background.svg";
 
 import DutyContent from "@components/shared/DutyContent";
-
 import Footer from "@components/shared/Footer";
 import IconTitle from "@components/shared/IconTitle";
 
@@ -13,6 +13,7 @@ import "./style.scss";
 const DutyPage = ({ text }) => {
   return (
     <div id="duty">
+      <Helmet title={`Python Brasil 2022 | ${text.CDC.LANDING.TITLE}`} />
       <main>
         <div className="duty__adornment">
           <img

--- a/src/components/pages/HomePage/index.js
+++ b/src/components/pages/HomePage/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet";
 
 import TitleChip from "@components/shared/TitleChip";
 import Footer from "@components/shared/Footer";
@@ -68,6 +69,8 @@ const HomePage = ({ text, file }) => {
 
   return (
     <div id="home">
+      <Helmet title="Python Brasil 2022" />
+
       <section id="section-landing-page">
         <div className="container">
           <div className="row desktop-only">

--- a/src/components/shared/Layout/index.js
+++ b/src/components/shared/Layout/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { StaticQuery, graphql } from 'gatsby'
 import GeneralContext from '@configs/context'
 import Header from '@components/Header'
+import { Helmet } from 'react-helmet'
 
 const Layout = ({ children }) => (
   <StaticQuery
@@ -19,6 +20,7 @@ const Layout = ({ children }) => (
       <GeneralContext.Consumer>
         {theme => (
           <div>
+            <Helmet title={data.site.siteMetadata.title} />
             <Header siteTitle={data.site.siteMetadata.title} language={theme.language} />
             <div>
               {children}


### PR DESCRIPTION
## Links:
- [Issue#66](https://github.com/pythonbrasil/pybr2022-site/issues/66)

## Descrição
- Nesse PR adicionei os títulos das paginas ao site
- Na documentação é recomendado usar o react-helmet com o [plugin gastby-plugin-react-helmet](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/)



## Como testar:
- Rode a aplicação com `yarn start` ou `yarn develop` ou `make run`
- Observe o icon na tab do navegador
- O titulo das páginas devem aparecer na tab do navegador

## Screenshots:

Chromium
![image](https://user-images.githubusercontent.com/42525687/171518839-31e88c19-4b63-4ca5-9216-9428beb6c204.png)

Firefox
![image](https://user-images.githubusercontent.com/42525687/171518883-0dfeef0b-072c-4b42-ad07-5a10ba35df9f.png)









**Pull-request sponsored by** 
[![image](https://s3-us-west-2.amazonaws.com/labcodes.com.br/lab/labcodes-328x120.png)](https://labcodes.com.br/)


